### PR TITLE
changed login validation to unified login error message

### DIFF
--- a/backend/src/controllers/loginController.js
+++ b/backend/src/controllers/loginController.js
@@ -7,14 +7,9 @@ exports.loginUser = async (req, res) => {
         const { username, password } = req.body
         const user = await User.findOne({ username })
 
-        if (!user) {
-            return res.status(401).json({ message: 'Username not found' })
-        }
-
-        const passwordMatch = await bcrypt.compare(password, user.password)
-
-        if (!passwordMatch) {
-            return res.status(401).json({ message: 'Incorrect password' })
+        if (!user || !(await bcrypt.compare(password, user.password))) {
+            // Unified failure message
+            return res.status(401).json({ message: 'Invalid username and/or password' })
         }
 
         const token = await jwtHandler.signToken(user)


### PR DESCRIPTION
answers this >> **Authentication failure responses should not indicate which part of the authentication data was incorrect. For example, instead of "Invalid
username" or "Invalid password", just use "Invalid username and/or
password" for both**